### PR TITLE
Increase waitgroup inside WithOSSignals

### DIFF
--- a/shutdown/example_http_test.go
+++ b/shutdown/example_http_test.go
@@ -16,7 +16,6 @@ func ExampleWithOSSignals() {
 		Addr: "0.0.0.0:8080",
 	}
 	wg := &sync.WaitGroup{}
-	wg.Add(1)
 	shutdown.WithOSSignals(s, 5*time.Second, wg, func(err error) { // We can also pass nil as errHandler func if we dont care about errors.
 		fmt.Printf("shutdown error: %v \n", err)
 	})

--- a/shutdown/http.go
+++ b/shutdown/http.go
@@ -18,6 +18,7 @@ import (
 func WithOSSignals(s *http.Server, timeout time.Duration, wg *sync.WaitGroup, errHandler func(err error)) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		<-signals


### PR DESCRIPTION
Increasing the `WaitGroup` inside `WithOSSignals`, we avoid doing it outside the function each time we call it.